### PR TITLE
Fix for an error in windows.

### DIFF
--- a/tasks/jsdoc-plugin.js
+++ b/tasks/jsdoc-plugin.js
@@ -46,7 +46,7 @@ module.exports = function jsDocTask(grunt) {
 		 * @return {String} command the command ready to be executed
 		 */
 		var buildCmd = function(bin, sources, destination){
-			var cmd = bin + ' -d ' + destination +' ' + sources.join(' ');
+			var cmd = '"' + bin  + '"' + ' -d ' + destination +' ' + sources.join(' ');
 			grunt.log.debug(cmd);
 			return cmd;
 		};


### PR DESCRIPTION
This fixes the following error in windows:

    $ grunt jsdoc
    Running "jsdoc:dist" (jsdoc) task
    >> jsdoc error: Error: Command failed: 'node_modules' is not recognized as an internal or external command,
    >> operable program or batch file.
    Warning: jsdoc failure Use --force to continue.

    Aborted due to warnings.

Once this is merged, the plugin should be fully compatible with windows.
