### PR TITLE
Typo, #29 should be fixed now.

### DIFF
--- a/tasks/jsdoc-plugin.js
+++ b/tasks/jsdoc-plugin.js
@@ -54,7 +54,7 @@ module.exports = function jsDocTask(grunt) {
 		// Compute JSDoc flags from options
 		for(var optionName in options){
 			var option = options[optionName];
-			if(!grunt.util._.contains(cliFlags, optionName) || !options){
+			if(!grunt.util._.contains(cliFlags, optionName) || !option){
 				delete options[optionName];
 			}
 		}


### PR DESCRIPTION
See #29. If private: false is passed from `Gruntfile.js`, the option is now actually deleted instead of still passed to JSDoc.
