### PR TITLE
Correct sample configuration in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ grunt.initConfig({
         dist : {
             src: ['src/*.js', 'test/*.js'], 
             options: {
-                destination: 'doc'
+                dest: 'doc'
             }
         }
     }


### PR DESCRIPTION
Ensure that the correct configuration options are reflected in the configuration used by `grunt-jsdoc`.
