### PR TITLE
Allow latest command line parameters

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,12 +67,12 @@ The supported options are
  * `src` : (required) an array of pattern that matches the files to extract the documentation from. You can also add the pattern to a README.md file to include it in your doc as described [there](http://usejsdoc.org/about-including-readme.html).
  * `dest` : (alias to `options.destination`) set up the destination folder, the grunt way
  * `jsdoc`: (optional) the path to the jsdoc bin (needed only for some border line cases)
- * `options` : options used by jsdoc 
+ * `options` : full name command line options recognized by jsdoc, e.g.
    * `destination`: (required) the folder where the doc is generated
    * `configure` : (optional) path to a config file
    * `template` : (optional) path or name to a different template
-   * `private` : (optional) include the private functions to the doc (`true` by default).
-   * ... refer the [usejsdocCli] documentation for all the available options.
+   * `private` : (optional) include the private functions to the doc
+   * ... Refer to the [usejsdocCli] documentation for all the available options.
 
 Then, load the plugin 
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "grunt-jsdoc",
   "description": "Integrates jsdoc3 generation into your Grunt build",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "homepage": "https://github.com/krampstudio/grunt-jsdoc",
   "author": {
     "name": "Bertrand Chevrier",

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "grunt-contrib-nodeunit": "~0.4.0"
   },
   "dependencies": {
-    "jsdoc": "~3.3.0",
+    "jsdoc": "~3.3.0-alpha9",
     "ink-docstrap": "~0.4.12"
   },
   "peerDependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "grunt-jsdoc",
   "description": "Integrates jsdoc3 generation into your Grunt build",
-  "version": "0.5.6",
+  "version": "0.6.0",
   "homepage": "https://github.com/krampstudio/grunt-jsdoc",
   "author": {
     "name": "Bertrand Chevrier",
@@ -43,8 +43,8 @@
     "grunt-contrib-nodeunit": "~0.4.0"
   },
   "dependencies": {
-    "jsdoc": "~3.2.2",
-    "ink-docstrap": "~0.4.5"
+    "jsdoc": "~3.3.0",
+    "ink-docstrap": "~0.4.12"
   },
   "peerDependencies": {
     "grunt": "~0.4.0"

--- a/tasks/jsdoc-plugin.js
+++ b/tasks/jsdoc-plugin.js
@@ -33,7 +33,7 @@ module.exports = function jsDocTask(grunt) {
 			done			= grunt.task.current.async(),
 			srcs			= grunt.task.current.filesSrc,
 			jsDocPath		= grunt.task.current.data.jsdoc,
-			jsDocNpmPath	= 'node_modules/jsdoc/jsdoc',
+			jsDocNpmPath	= 'node_modules/.bin/jsdoc',
 			timeout			= 60000,	//todo implement and move in options
 			cliFlags = ['recurse', 'private', 'lenient', 'explain', 'help', 'version', 'test', 'verbose', 'nocolor', 'template', 'configure', 'destination', 'encoding', 'tutorials', 'match', 'query'],
 			jsDoc;
@@ -71,7 +71,7 @@ module.exports = function jsDocTask(grunt) {
         // convert jsdoc path to relative path
         jsDoc = path.relative('.', jsDoc);//, path.resolve('.'));
 
-		//check if jsdoc npm module is installedz
+		//check if jsdoc npm module is installed
 		if(jsDoc === undefined){
 			grunt.log.error('Unable to locate jsdoc');
 			grunt.fail.warn('Wrong installation/environnement', errorCode.generic);

--- a/tasks/jsdoc-plugin.js
+++ b/tasks/jsdoc-plugin.js
@@ -29,13 +29,14 @@ module.exports = function jsDocTask(grunt) {
 		var fs				= require('fs'),
 			path			= require('path'),
 			exec			= require('./lib/exec'),
-			options			= grunt.task.current.options({'private': true}),
+			options			= grunt.task.current.options(),
 			done			= grunt.task.current.async(),
 			srcs			= grunt.task.current.filesSrc,
 			jsDocPath		= grunt.task.current.data.jsdoc,
 			jsDocNpmPath	= 'node_modules/.bin/jsdoc',
 			timeout			= 60000,	//todo implement and move in options
-			cliFlags = ['recurse', 'private', 'lenient', 'explain', 'help', 'version', 'test', 'verbose', 'nocolor', 'template', 'configure', 'destination', 'encoding', 'tutorials', 'match', 'query'],
+			// Keep in sync with JSDoc's lib/jsdoc/opts/args.js
+			cliFlags = ['access', 'configure', 'destination', 'debug', 'encoding', 'help', 'match', 'nocolor', 'private', 'package', 'pedantic', 'query', 'recurse', 'readme', 'template', 'test', 'tutorials', 'version', 'verbose', 'explain'],
 			jsDoc;
 
 		//validate options


### PR DESCRIPTION
Since the latest update a couple of new command line parameters have been added to JSDoc.
This commit aligns the grunt-jsdoc source with the latest jsdoc source to allow the latest command line parameters in the gruntfile options.