### PR TITLE
Only fail on error, add option to ignore warnings

### DIFF
--- a/tasks/jsdoc-plugin.js
+++ b/tasks/jsdoc-plugin.js
@@ -100,17 +100,14 @@ module.exports = function jsDocTask(grunt) {
 
 			//execution of the jsdoc command
 			var child = exec.buildSpawned(grunt, jsDoc, srcs, options);
-			var wereErrors = false;
 
 			child.stdout.on('data', grunt.log.debug)
 			child.stderr.on('data', function(data) {
-				if (data.toString().lastIndexOf('ERROR:', 0) === 0)
-					wereErrors = true;
 				if (!options.ignoreWarnings)
 					grunt.log.error(data);
 			});
 			child.on('exit', function(code){
-				if(code === 0 && !wereErrors){
+				if(code === 0){
 					grunt.log.write('Documentation generated to ' + path.resolve(options.destination));
 					done(true);
 				} else {

--- a/tasks/jsdoc-plugin.js
+++ b/tasks/jsdoc-plugin.js
@@ -100,20 +100,21 @@ module.exports = function jsDocTask(grunt) {
 
 			//execution of the jsdoc command
 			var child = exec.buildSpawned(grunt, jsDoc, srcs, options);
-			child.stdout.on('data', function (data) {
-				grunt.log.debug('jsdoc output : ' + data);
-			});
-			child.stderr.on('data', function (data) {
-				grunt.log.error('An error occurs in jsdoc process:\n' + data);
-				grunt.fail.warn('jsdoc failure', errorCode.task);
+			var wereErrors = false;
+
+			child.stdout.on('data', grunt.log.debug)
+			child.stderr.on('data', function(data) {
+				if (data.toString().lastIndexOf('ERROR:', 0) === 0)
+					wereErrors = true;
+				if (!options.ignoreWarnings)
+					grunt.log.error(data);
 			});
 			child.on('exit', function(code){
-				if(code === 0){
+				if(code === 0 && !wereErrors){
 					grunt.log.write('Documentation generated to ' + path.resolve(options.destination));
 					done(true);
 				} else {
-					grunt.log.error('jsdoc terminated');
-					grunt.fail.warn('jsdoc failure', errorCode.task);
+					grunt.fail.warn('jsdoc terminated with a non-zero exit code', errorCode.task);
 				}
 			});
 		});


### PR DESCRIPTION
This pull request extends on the error checking a bit to ignore
warnings. Warnings do not necessitate a complete failure. For example,
with ES6, you're gonna get warnings about new stuff no matter what –
you can still generate docs!

Furthermore, added an ignoreWarnings option to not print warnings.