### PR TITLE
Fix bug whereby discrete jsdoc dependency prevents executable being found

### DIFF
--- a/tasks/lib/exec.js
+++ b/tasks/lib/exec.js
@@ -67,7 +67,8 @@ module.exports = {
 		//check first the base path into the cwd
 		paths = [
             __dirname + '/../../node_modules/.bin/jsdoc',
-            __dirname + '/../../node_modules/jsdoc/jsdoc.js'
+            __dirname + '/../../node_modules/jsdoc/jsdoc.js',
+            __dirname + '/../../../jsdoc/jsdoc.js'
         ];
 
         //fall back on global if not found at the usual location


### PR DESCRIPTION
When the jsdoc npm plugin is installed separately, it will not be found within the dependencies of this grunt plugin, and will give the error `Unable to locate jsdoc`.

This pull-request adds an extra path location to the lookup function which will check for a discrete jsdoc plugin prior to failing because jsdoc cannot be found.