### PR TITLE
Call done() on failure to prevent Grunt hanging

### DIFF
--- a/tasks/jsdoc-plugin.js
+++ b/tasks/jsdoc-plugin.js
@@ -115,6 +115,7 @@ module.exports = function jsDocTask(grunt) {
                 done(true);
             } else {
                 grunt.fail.warn('jsdoc terminated with a non-zero exit code', errorCode.task);
+                done();
             }
         });
     });


### PR DESCRIPTION
This fixes issue #140 by calling `done()` when the task is finished, regardless of whether it succeeded. I have not passed a boolean `true` in, because it doesn't seem to be required.

The output of `npm test` still passes. I would write a test for this, but I'm struggling to think of a way of testing it without running the entire task as a child process.