### PR TITLE
Make windows use node to run javascript files.

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -62,10 +62,10 @@ module.exports = function(grunt) {
     //testing tasks
     grunt.registerTask('default', 'Default tas will lint and test', ['jshint', 'test']);
     grunt.registerTask('test-basic', 'Test basic jsdoc', ['jsdoc:basic', 'nodeunit:basic']);
-    grunt.registerTask('test-basic', 'Test jsdoc with alternate options', ['jsdoc:alternate', 'nodeunit:alternate']);
+    grunt.registerTask('test-alternate', 'Test jsdoc with alternate options', ['jsdoc:alternate', 'nodeunit:alternate']);
     grunt.registerTask('test-docstrap', 'Test jsdoc with a template', ['jsdoc:docstrap', 'nodeunit:docstrap']);
     grunt.registerTask('test-spacepack', 'Test jsdoc with a package and spaces in the paths', ['jsdoc:spacepack', 'nodeunit:spacepack']);
-    grunt.registerTask('test', 'Full test suite', ['clean', 'nodeunit:unit', 'test-basic', 'test-docstrap', 'test-spacepack']);
+    grunt.registerTask('test', 'Full test suite', ['clean', 'nodeunit:unit', 'test-basic', 'test-alternate', 'test-docstrap', 'test-spacepack']);
 
 };
 

--- a/tasks/lib/exec.js
+++ b/tasks/lib/exec.js
@@ -20,7 +20,7 @@ module.exports = {
 
         var flag;
 		var cmd = (isWin) ? 'cmd' : script;
-		var args = (isWin) ? ['/c', script] : [];
+		var args = (isWin) ? ['/c', script.slice(-2) === 'js' ? 'node ' + script : script] : [];
 
 
          // handle paths that contain spaces


### PR DESCRIPTION
I had an issue where my default file handler for javascript files was to open them in gvim. I can't imagine I'd be the only person doing node.js and working with javascript all day who wouldn't want double-clicking a javascript file to open it for editing or do something other than trying to run it. Because this just ran `cmd /c` on the file it found, trying to do `grunt jsdoc` would open jsdoc.js in my editor instead of creating documentation.

This change makes it so that if lib/exec.lookup returns a path ending in 'js' that the command used will be `cmd /c node ` then script. I also noticed `test-basic` was duplicated for the alternate so I made `test-alternate` it's own task and called it in the `test` task.

I don't know enough about the testing to add a test specifically for this (I still need to learn that), but I did run all the tests where it wasn't finding the js file, then delete the bash script (I'm in cygwin) that it was finding and run it again where it was hitting jsdoc.js and saw the tests still pass and it use node (via`grunt --debug test`). If this needs an explicit test before going in I'll have to go spend some time learning how.