### PR TITLE
Added 'pipe' option

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ The supported options are
  * `jsdoc`: (optional) the path to the jsdoc bin (needed only for some border line cases)
  * `options` : options used by jsdoc
    * `destination`: the folder where the doc is generated
+   * `pipe`: Pipe all of the output from jsdoc to the specified file. Useful for JSON exports
    * ... All jsdoc options are available (see [usejsdocCli](http://usejsdoc.org/about-commandline.html) documentation).
    * `ignoreWarnings` : (optional) do not show jsdoc warnings
 

--- a/tasks/jsdoc-plugin.js
+++ b/tasks/jsdoc-plugin.js
@@ -110,6 +110,35 @@ module.exports = function jsDocTask(grunt) {
                 grunt.log.error(data);
             }
         });
+
+        if(options.pipe) {
+
+            var pipeContent = '';
+            child.stdout.on('data', function (data) {
+                pipeContent = pipeContent + data;
+            })
+
+            child.on('exit', function(code) {
+                grunt.file.write(options.pipe, pipeContent);
+            });
+
+            /*
+
+             This is an alternative that works better for larger files, but breaks convention
+
+             var fs = require('fs');
+             var writeStream = fs.createWriteStream(options.pipe);
+             child.stdout.on('data', function (data) {
+                writeStream.write(data);
+             })
+             child.on('exit', function(code) {
+                writeStream.end();
+             });
+
+             */
+        }
+
+
         child.on('exit', function(code) {
             if (code === 0) {
                 if(options.destination){


### PR DESCRIPTION
Found that if I'm trying to use the 'haruki' template (json export), it only writes to stdout. This adds a flag to capture output to stdout and write it to the specified file. 
