### PR TITLE
Update JSDoc to 3.5.5

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
   },
   "dependencies": {
     "cross-spawn": "^3.0.1",
-    "jsdoc": "~3.4.0"
+    "jsdoc": "~3.5.5"
   },
   "peerDependencies": {
     "grunt": ">=0.4.5"


### PR DESCRIPTION
This fixes [a problem in JSDoc's fs module that arose with Node 8.5.0](https://github.com/jsdoc3/jsdoc/issues/1438).  JSDoc fixed this in 3.5.5, so all this does is bump the version that grunt-jsdoc uses.